### PR TITLE
Fixed placemark extraction issue with sub folders

### DIFF
--- a/kml.js
+++ b/kml.js
@@ -25,12 +25,11 @@ class KML
             req.onload = (e) => {
                 let doc = this.doc = req.response;
                 this.name = $(doc).find('name').first().text();
-                // Look for folders
+                // Look for all folders that exist. For each folder look for Placemark tags that are top level children of that folder.
                 let folders = $(doc).find('Folder');
                 for (let folder of folders)
                 {
-                    // Look for placemarks
-                    let placemarks = $(folder).find('Placemark');
+                    let placemarks = $(folder).children('Placemark');
                     let locations = [];
                     for (let placemark of placemarks)
                     {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
 
-const app_version = "v1.4.3";
+const app_version = "v1.4.4";
 
 const addResourcesToCache = async (resources) => {
     const cache = await caches.open(app_version);


### PR DESCRIPTION
Placemarks are only extracted when they are direct children of a folder. This avoids extracting the same placemark multiple times.